### PR TITLE
Complex Object Determination

### DIFF
--- a/fixcsv.py
+++ b/fixcsv.py
@@ -79,21 +79,23 @@ def backup_original(filepath: str) -> str:
     return backup_path
 
 
-def get_apply_to(fix: dict[str, Any]) -> str:
-    """Return the row scope for a fix"""
-    return str(fix.get("apply_to", "all"))
+def get_which(fix: dict[str, Any]) -> str:
+    """Return the row scope for a fix."""
+    if "which" in fix:
+        return str(fix["which"])
+    return "all"
 
 
-def should_apply_fix(row: pd.Series, apply_to: str) -> bool:
-    """Return True when a fix should run on the given row"""
-    if apply_to == "all":
+def should_apply_fix(row: pd.Series, which: str) -> bool:
+    """Return True when a fix should run on the given row."""
+    if which == "all":
         return True
-    if apply_to == "complex":
+    elif which == "complex":
         return is_complex(row)
-    if apply_to == "non_complex":
+    elif which in {"item"}:
         return not is_complex(row)
-
-    raise ValueError(f"ERROR: Unknown apply_to value: {apply_to}")
+    else:
+        raise ValueError(f"ERROR: Unknown which value: {which}")
 
 
 def fix_strip_column(df: pd.DataFrame, column: str, fix: dict[str, Any]) -> Tuple[pd.DataFrame, int]:
@@ -102,11 +104,11 @@ def fix_strip_column(df: pd.DataFrame, column: str, fix: dict[str, Any]) -> Tupl
         logger.warning(f"Column '{column}' not found in CSV, skipping")
         return df, 0
 
-    apply_to = get_apply_to(fix)
+    which = get_which(fix)
     
     changes = 0
     for idx in df.index:
-        if not should_apply_fix(df.loc[idx], apply_to):
+        if not should_apply_fix(df.loc[idx], which):
             continue
         if pd.notna(df.at[idx, column]):
             original = str(df.at[idx, column])
@@ -125,7 +127,7 @@ def fix_regex_replace(df: pd.DataFrame, column: str, pattern: str, replacement: 
         logger.warning(f"Column '{column}' not found in CSV, skipping")
         return df, 0
 
-    apply_to = get_apply_to(fix)
+    which = get_which(fix)
     
     changes = 0
     compiled_pattern = re.compile(pattern)
@@ -134,7 +136,7 @@ def fix_regex_replace(df: pd.DataFrame, column: str, pattern: str, replacement: 
     # If it's the same, then it was good before
     # This doesn't repeat things like .tif extensions because the fix yaml already specifies to exclude things ending in .tif.
     for idx in df.index:
-        if not should_apply_fix(df.loc[idx], apply_to):
+        if not should_apply_fix(df.loc[idx], which):
             continue
         if pd.notna(df.at[idx, column]):
             original = str(df.at[idx, column])
@@ -154,7 +156,7 @@ def fix_enforce_string(df: pd.DataFrame, column: str, validation_config: dict[st
         logger.warning(f"No validation rule for '{column}', skipping")
         return df, 0
 
-    apply_to = get_apply_to(fix)
+    which = get_which(fix)
     
     # Find the string validation rule
     expected_value = None
@@ -170,7 +172,7 @@ def fix_enforce_string(df: pd.DataFrame, column: str, validation_config: dict[st
     # Apply the fix
     changes = 0
     for idx in df.index:
-        if not should_apply_fix(df.loc[idx], apply_to):
+        if not should_apply_fix(df.loc[idx], which):
             continue
         if pd.notna(df.at[idx, column]):
             current = str(df.at[idx, column])

--- a/fixcsv.py
+++ b/fixcsv.py
@@ -14,6 +14,7 @@ import shutil
 import sys
 import re
 from typing import Any, Tuple
+from utils import is_complex
 
 
 # Configure logging
@@ -78,14 +79,35 @@ def backup_original(filepath: str) -> str:
     return backup_path
 
 
-def fix_strip_column(df: pd.DataFrame, column: str) -> Tuple[pd.DataFrame, int]:
+def get_apply_to(fix: dict[str, Any]) -> str:
+    """Return the row scope for a fix"""
+    return str(fix.get("apply_to", "all"))
+
+
+def should_apply_fix(row: pd.Series, apply_to: str) -> bool:
+    """Return True when a fix should run on the given row"""
+    if apply_to == "all":
+        return True
+    if apply_to == "complex":
+        return is_complex(row)
+    if apply_to == "non_complex":
+        return not is_complex(row)
+
+    raise ValueError(f"ERROR: Unknown apply_to value: {apply_to}")
+
+
+def fix_strip_column(df: pd.DataFrame, column: str, fix: dict[str, Any]) -> Tuple[pd.DataFrame, int]:
     """Strip leading/trailing whitespace from all values in a column"""
     if column not in df.columns:
         logger.warning(f"Column '{column}' not found in CSV, skipping")
         return df, 0
+
+    apply_to = get_apply_to(fix)
     
     changes = 0
     for idx in df.index:
+        if not should_apply_fix(df.loc[idx], apply_to):
+            continue
         if pd.notna(df.at[idx, column]):
             original = str(df.at[idx, column])
             stripped = original.strip()
@@ -97,11 +119,13 @@ def fix_strip_column(df: pd.DataFrame, column: str) -> Tuple[pd.DataFrame, int]:
     return df, changes
 
 
-def fix_regex_replace(df: pd.DataFrame, column: str, pattern: str, replacement: str) -> Tuple[pd.DataFrame, int]:
+def fix_regex_replace(df: pd.DataFrame, column: str, pattern: str, replacement: str, fix: dict[str, Any]) -> Tuple[pd.DataFrame, int]:
     """Apply regex replacement to all values in a column"""
     if column not in df.columns:
         logger.warning(f"Column '{column}' not found in CSV, skipping")
         return df, 0
+
+    apply_to = get_apply_to(fix)
     
     changes = 0
     compiled_pattern = re.compile(pattern)
@@ -110,6 +134,8 @@ def fix_regex_replace(df: pd.DataFrame, column: str, pattern: str, replacement: 
     # If it's the same, then it was good before
     # This doesn't repeat things like .tif extensions because the fix yaml already specifies to exclude things ending in .tif.
     for idx in df.index:
+        if not should_apply_fix(df.loc[idx], apply_to):
+            continue
         if pd.notna(df.at[idx, column]):
             original = str(df.at[idx, column])
             replaced = compiled_pattern.sub(replacement, original)
@@ -121,12 +147,14 @@ def fix_regex_replace(df: pd.DataFrame, column: str, pattern: str, replacement: 
     return df, changes
 
 
-def fix_enforce_string(df: pd.DataFrame, column: str, validation_config: dict[str, Any]) -> Tuple[pd.DataFrame, int]:
+def fix_enforce_string(df: pd.DataFrame, column: str, validation_config: dict[str, Any], fix: dict[str, Any]) -> Tuple[pd.DataFrame, int]:
     """Enforce the string value defined in validation config"""
     # Look up what the string should be
     if column not in validation_config or not validation_config[column]:
         logger.warning(f"No validation rule for '{column}', skipping")
         return df, 0
+
+    apply_to = get_apply_to(fix)
     
     # Find the string validation rule
     expected_value = None
@@ -142,6 +170,8 @@ def fix_enforce_string(df: pd.DataFrame, column: str, validation_config: dict[st
     # Apply the fix
     changes = 0
     for idx in df.index:
+        if not should_apply_fix(df.loc[idx], apply_to):
+            continue
         if pd.notna(df.at[idx, column]):
             current = str(df.at[idx, column])
             if current != expected_value:
@@ -164,7 +194,7 @@ def apply_collection_fixes(df: pd.DataFrame, fix_config: dict[str, Any], validat
                 logger.error(f"Fix missing 'column' field: {fix}")
                 continue
             
-            df, changes = fix_strip_column(df, column)
+            df, changes = fix_strip_column(df, column, fix)
             logger.info(f"  Strip whitespace in '{column}': {changes} changes")
             total_changes += changes
             
@@ -177,13 +207,13 @@ def apply_collection_fixes(df: pd.DataFrame, fix_config: dict[str, Any], validat
                 logger.error(f"regex_replace missing required fields: {fix}")
                 continue
             
-            df, changes = fix_regex_replace(df, column, pattern, replacement)
+            df, changes = fix_regex_replace(df, column, pattern, replacement, fix)
             logger.info(f"  Regex replace in '{column}': {changes} changes")
             total_changes += changes
             
         elif fix_type == 'enforce_string':
             column = fix.get('column')
-            df, changes = fix_enforce_string(df, column, validation_config)
+            df, changes = fix_enforce_string(df, column, validation_config, fix)
             logger.info(f"  Enforce string in '{column}': {changes} changes")
             total_changes += changes
 

--- a/headers_fixes_config/default.yaml
+++ b/headers_fixes_config/default.yaml
@@ -1,6 +1,6 @@
 file:
   - check_filenames_assets: ['file']
-    which: all
+    which: item
 subject:
   - validate_controlled_vocab: ['subject']
     which: all

--- a/headers_fixes_config/uo-athletics-fixes.yaml
+++ b/headers_fixes_config/uo-athletics-fixes.yaml
@@ -22,4 +22,4 @@ fixes:
     column: file
     pattern: '^(.*?)(?<!\.tif)$'
     replacement: '\1.tif'
-    apply_to: non_complex
+    which: item

--- a/headers_fixes_config/uo-athletics-fixes.yaml
+++ b/headers_fixes_config/uo-athletics-fixes.yaml
@@ -22,3 +22,4 @@ fixes:
     column: file
     pattern: '^(.*?)(?<!\.tif)$'
     replacement: '\1.tif'
+    apply_to: non_complex

--- a/headers_fixes_config/uo-athletics.yaml
+++ b/headers_fixes_config/uo-athletics.yaml
@@ -1,13 +1,18 @@
 file:
   - check_filenames_assets: ['file']
-    which: all
+    which: item
   - identifier_file_match: ['.tif']
-    which: all
+    which: item
 title: ~
 description: ~
 identifier:
   - regex: ^PH395_UP\S*$
-    which: all
+    which: item
+    #FIXME: This accepts either valid value for a complex identifier. It doesn't
+    # actually ensure that both are present. It's hard to design a regex check
+    # with our methods because we automatically split on pipes.
+  - regex: '^(?:PH395_UP\S*|[0-9]+(?:_[A-Za-z0-9&-]+)+)$'
+    which: complex
 local_collection_name:
   - string: http://opaquenamespace.org/ns/localCollectionName/UniversityPhotosPaulHarveyIV
     which: all
@@ -28,7 +33,9 @@ location:
     which: all
 resource_type:
   - string: http://purl.org/dc/dcmitype/Image
-    which: all
+    which: item
+  - string: http://purl.org/dc/dcmitype/Collection
+    which: complex
 format:
   - string: https://w3id.org/spar/mediatype/image/tiff
     which: all
@@ -49,7 +56,9 @@ institution:
     which: all
 model:
   - string: Image
-    which: all
+    which: item
+  - string: Generic
+    which: complex
 has_finding_aid:
   - string: https://scua.uoregon.edu/repositories/2/resources/9512
     which: all

--- a/od2validation.py
+++ b/od2validation.py
@@ -179,16 +179,13 @@ class Package(object):
         """Return filtered df that filters for all, only complex objects, or only items"""
         if which == "all":
             return df
+
+        complex_mask = df.apply(utils.is_complex, axis=1)
         if which == "complex":
-            if "format" not in df.columns:
-                logger.error("complex objects need 'format' col")
-                return df.iloc[0:0]
-            return df[df["format"] == "https://w3id.org/spar/mediatype/application/xml"]
+            return df[complex_mask]
         if which == "item":
-            if "format" not in df.columns:
-                logger.error("complex object has unexpected 'format' value")
-                return df.iloc[0:0]
-            return df[(df["format"].isna()) | (df["format"] != "https://w3id.org/spar/mediatype/application/xml")]
+            return df[~complex_mask]
+
         logger.error(f"Invalid 'which' parameter: {which}")
         return df.iloc[0:0]
     
@@ -325,8 +322,8 @@ class FilenamesAssetsInstruction(Instruction):
         # Building dict mapping file names to the row where each filename appears 
         # (this assumes file names are unique per sheet)
         filenames_by_value: Dict[str, int] = {}
-        for idx in df.index:
-            for v in package.values_for_header(df, base_col, idx):
+        for idx in rows.index:
+            for v in package.values_for_header(rows, base_col, idx):
                 #FIXME Skip empty? That's what we do now with the strip and 'if not v'
                 v = v.strip()
                 if not v:
@@ -364,10 +361,9 @@ class IdentifierFileInstruction(Instruction):
     
     def execute(self, package, df, header, rows) -> None:
         substring: str = self.args[0]
-        df_for_method: pd.DataFrame = package.get_dataframe()
         validation_errors = []
-        
-        for index, row in df_for_method.iterrows():
+
+        for index, row in rows.iterrows():
             actual_id = str(row['identifier'])
             # Remove file ending from file (leftover should match identifier)
             expected_id = str(row['file']).replace(substring, '')

--- a/od2validation.py
+++ b/od2validation.py
@@ -180,6 +180,8 @@ class Package(object):
         if which == "all":
             return df
 
+        # Create a mask by checking for complex objects in each row in the df. 
+        # Return the mask itself or the inversion of the mask (all non-complex objects), depending on filter.
         complex_mask = df.apply(utils.is_complex, axis=1)
         if which == "complex":
             return df[complex_mask]

--- a/od2validation.py
+++ b/od2validation.py
@@ -173,7 +173,8 @@ class Package(object):
             for instruction in self._resolve_instructions(real_header):
                 errors.extend(self._run_instruction(df, real_header, instruction))
         return errors
-    
+
+    #FIXME: Swap the complex check here to use utils.py version
     def _select_rows(self, df: pd.DataFrame, which: str) -> pd.DataFrame:
         """Return filtered df that filters for all, only complex objects, or only items"""
         if which == "all":

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,8 @@
 import re
 
+COMPLEX_MODEL_VALUE = "generic"
+COMPLEX_RESOURCE_TYPE_VALUE = "http://purl.org/dc/dcmitype/Collection"
+
 def base_header(header: str) -> str:
     """Return the base header without _X for an enumerated header"""
     return re.sub(r'_\d+$', '', header)
@@ -7,4 +10,8 @@ def base_header(header: str) -> str:
 def is_complex(row) -> bool:
     """Return True if row is complex, False otherwise"""
     #FIXME: Should the check be using model generic or format = xml link?
-    return row.get("model").lower() == "generic"
+    if "model" not in row or "resource_type" not in row:
+        raise KeyError("Row does not contain column for 'model' or 'resource_type'")
+    model = str(row.get("model")).lower()
+    resource = str(row.get("resource_type")).lower()
+    return model == COMPLEX_MODEL_VALUE.lower() and resource == COMPLEX_RESOURCE_TYPE_VALUE.lower()

--- a/utils.py
+++ b/utils.py
@@ -3,3 +3,8 @@ import re
 def base_header(header: str) -> str:
     """Return the base header without _X for an enumerated header"""
     return re.sub(r'_\d+$', '', header)
+
+def is_complex(row) -> bool:
+    """Return True if row is complex, False otherwise"""
+    #FIXME: Should the check be using model generic or format = xml link?
+    return row.get("model").lower() == "generic"


### PR DESCRIPTION
Add a function is_complex to utils.py to determine if rows are complex objects. Based on that:
- Allow filtering in fixcsv.py, which in turn allows 'which' statements in fix configs.
- Simplify _select_rows in od2validation.py using new is_complex function
- Update FilenamesAssetsInstruction to use filtered dataframe rather than unfiltered (this lets 'which' statement work for it)
- Update existing configs in uo-athletics to handle complex vs non-complex checks.
Fixes #9 and can be used in #48.