### PR TITLE
Complex tool

### DIFF
--- a/make_id_list.py
+++ b/make_id_list.py
@@ -1,0 +1,17 @@
+"""Generate pipe-separated list of files"""
+import csv, os
+
+# Could make a function that does this outside of main, so that you can call that to automate this whole part of the process
+
+def main():
+    filepath = input("Enter filepath to csv: ")
+    with open(filepath, "r", encoding="utf-8-sig") as csvf:
+            reader = csv.DictReader(csvf)
+            #FIXME: This won't ignore if a complex ID is in the column
+            unformatted_ids = [row["identifier"] for row in reader]
+    formatted_ids = '|'.join(unformatted_ids)
+    print(formatted_ids)
+
+
+if __name__ == "__main__":
+    main()

--- a/make_id_list.py
+++ b/make_id_list.py
@@ -3,6 +3,7 @@ import csv, os
 
 # Could make a function that does this outside of main, so that you can call that to automate this whole part of the process
 
+#FIXME: Currently includes complex object id in the list. Skip this using is_complex from utils
 def main():
     filepath = input("Enter filepath to csv: ")
     with open(filepath, "r", encoding="utf-8-sig") as csvf:

--- a/make_id_list.py
+++ b/make_id_list.py
@@ -1,15 +1,23 @@
 """Generate pipe-separated list of files"""
 import csv, os
+from utils import is_complex
 
 # Could make a function that does this outside of main, so that you can call that to automate this whole part of the process
 
-#FIXME: Currently includes complex object id in the list. Skip this using is_complex from utils
 def main():
-    filepath = input("Enter filepath to csv: ")
+    filepath = input("Enter filepath to csv\n>>> ")
     with open(filepath, "r", encoding="utf-8-sig") as csvf:
             reader = csv.DictReader(csvf)
-            # Should be "id" column from export by default, but possible to change this if needed
-            unformatted_ids = [row["id"] for row in reader]
+            unformatted_ids = []
+
+            for row in reader:
+                # Should be "id" column from export by default, but possible to change this if needed
+                row_id = (row.get("id", "")).strip()
+                if not row_id:
+                     raise ValueError(f"Blank id found at row {reader.line_num}")
+                if not is_complex(row):
+                     unformatted_ids.append(row_id)
+            
     formatted_ids = '|'.join(unformatted_ids)
     print(formatted_ids)
 

--- a/make_id_list.py
+++ b/make_id_list.py
@@ -7,6 +7,7 @@ def main():
     filepath = input("Enter filepath to csv: ")
     with open(filepath, "r", encoding="utf-8-sig") as csvf:
             reader = csv.DictReader(csvf)
+            # Should be "id" column from export by default, but possible to change this if needed
             unformatted_ids = [row["id"] for row in reader]
     formatted_ids = '|'.join(unformatted_ids)
     print(formatted_ids)

--- a/make_id_list.py
+++ b/make_id_list.py
@@ -7,8 +7,7 @@ def main():
     filepath = input("Enter filepath to csv: ")
     with open(filepath, "r", encoding="utf-8-sig") as csvf:
             reader = csv.DictReader(csvf)
-            #FIXME: This won't ignore if a complex ID is in the column
-            unformatted_ids = [row["identifier"] for row in reader]
+            unformatted_ids = [row["id"] for row in reader]
     formatted_ids = '|'.join(unformatted_ids)
     print(formatted_ids)
 


### PR DESCRIPTION
Add make_id_list.py, which lets users copy a list of pipe-separated values from the "id" column of a csv. Skips any complex object id values. Fixes #48 